### PR TITLE
use no style whenever getting the format style for a file

### DIFF
--- a/clang-tools-extra/clangd/ClangdServer.cpp
+++ b/clang-tools-extra/clangd/ClangdServer.cpp
@@ -333,15 +333,11 @@ void ClangdServer::formatOnType(PathRef File, llvm::StringRef Code,
   auto Action = [File = File.str(), Code = Code.str(),
                  TriggerText = TriggerText.str(), CursorPos = *CursorPos,
                  CB = std::move(CB), this]() mutable {
-    auto Style = format::getStyle(format::DefaultFormatStyle, File,
-                                  format::DefaultFallbackStyle, Code,
-                                  TFS.view(/*CWD=*/llvm::None).get());
-    if (!Style)
-      return CB(Style.takeError());
+    auto Style = format::getNoStyle();
 
     std::vector<TextEdit> Result;
     for (const tooling::Replacement &R :
-         formatIncremental(Code, CursorPos, TriggerText, *Style))
+         formatIncremental(Code, CursorPos, TriggerText, Style))
       Result.push_back(replacementToEdit(Code, R));
     return CB(Result);
   };

--- a/clang-tools-extra/clangd/SourceCode.cpp
+++ b/clang-tools-extra/clangd/SourceCode.cpp
@@ -578,15 +578,9 @@ llvm::Optional<FileDigest> digestFile(const SourceManager &SM, FileID FID) {
 format::FormatStyle getFormatStyleForFile(llvm::StringRef File,
                                           llvm::StringRef Content,
                                           const ThreadsafeFS &TFS) {
-  auto Style = format::getStyle(format::DefaultFormatStyle, File,
-                                format::DefaultFallbackStyle, Content,
-                                TFS.view(/*CWD=*/llvm::None).get());
-  if (!Style) {
-    log("getStyle() failed for file {0}: {1}. Fallback is LLVM style.", File,
-        Style.takeError());
-    return format::getLLVMStyle();
-  }
-  return *Style;
+  auto Style = format::getNoStyle();
+
+  return Style;
 }
 
 llvm::Expected<tooling::Replacements>


### PR DESCRIPTION
Removes references to format::getStyle in the clangd extension to bypass clang-format checks in the case of incompatible clang-format updates